### PR TITLE
widen only whitespace

### DIFF
--- a/justifytext-library/src/main/java/me/biubiubiu/justifytext/library/JustifyTextView.java
+++ b/justifytext-library/src/main/java/me/biubiubiu/justifytext/library/JustifyTextView.java
@@ -62,12 +62,22 @@ public class JustifyTextView extends TextView {
             line = line.substring(3);
         }
 
-        float d = (mViewWidth - lineWidth) / line.length() - 1;
+        int nbSpaces = 0;
+        for (int i = 0; i < line.length(); i++) {
+            if (line.charAt(i) == ' ') {
+                nbSpaces++;
+            }
+        }
+        float d = (mViewWidth - lineWidth) / (nbSpaces - 1);
+
         for (int i = 0; i < line.length(); i++) {
             String c = String.valueOf(line.charAt(i));
             float cw = StaticLayout.getDesiredWidth(c, getPaint());
             canvas.drawText(c, x, mLineY, getPaint());
-            x += cw + d;
+            x += cw;
+            if (line.charAt(i) == ' ') {
+                x += d;
+            }
         }
     }
 


### PR DESCRIPTION
Text looks odd if there is some space between the letters. This makes it look like a standard TextView by keeping the letter spacing, and only extending the spaces width.
